### PR TITLE
chore(async): return worker pid when writing async

### DIFF
--- a/src/influxdb.app.src
+++ b/src/influxdb.app.src
@@ -1,6 +1,6 @@
 {application,influxdb,
              [{description,"InfluxDB Client"},
-              {vsn, "1.1.5"},
+              {vsn, "1.1.6"},
               {modules,[]},
               {registered,[influxdb_sup]},
               {applications,[kernel,stdlib,ehttpc,ecpool]},

--- a/src/influxdb.app.src
+++ b/src/influxdb.app.src
@@ -1,6 +1,6 @@
 {application,influxdb,
              [{description,"InfluxDB Client"},
-              {vsn, "1.1.6"},
+              {vsn,"git"},
               {modules,[]},
               {registered,[influxdb_sup]},
               {applications,[kernel,stdlib,ehttpc,ecpool]},

--- a/src/influxdb.appup.src
+++ b/src/influxdb.appup.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {VSN,
  [
-  {<<"1\\.1\\.[2-5]">>, [
+  {<<"1\\.1\\.[2-6]">>, [
     {load_module, influxdb_http, brutal_purge, soft_purge, []},
     {load_module, influxdb, brutal_purge, soft_purge, []}
   ]},

--- a/src/influxdb.appup.src
+++ b/src/influxdb.appup.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {VSN,
  [
-  {<<"1\\.1\\.[2-4]">>, [
+  {<<"1\\.1\\.[2-5]">>, [
     {load_module, influxdb_http, brutal_purge, soft_purge, []},
     {load_module, influxdb, brutal_purge, soft_purge, []}
   ]},
@@ -23,7 +23,7 @@
    {<<".*">>, []}
  ],
  [
-  {<<"1\\.1\\.[2-4]">>, [
+  {<<"1\\.1\\.[2-5]">>, [
     {load_module, influxdb_http, brutal_purge, soft_purge, []},
     {load_module, influxdb, brutal_purge, soft_purge, []}
   ]},

--- a/src/influxdb.erl
+++ b/src/influxdb.erl
@@ -32,7 +32,7 @@ start_client(Options0) ->
         pool => Pool,
         protocol => Protocol
     },
-    Options = lists:keydelete(protocol, 1, lists:keydelete(pool, 1, Options0)), 
+    Options = lists:keydelete(protocol, 1, lists:keydelete(pool, 1, Options0)),
     case Protocol of
         http ->
             case ehttpc_sup:start_pool(Pool, Options) of
@@ -106,7 +106,7 @@ write(#{protocol := Protocol} = Client, Key, Points) ->
         {error, R}
     end.
 
--spec(write_async(Client, Points, {ReplayFun, Args}) -> ok | {error, term()}
+-spec(write_async(Client, Points, {ReplayFun, Args}) -> {ok, pid()} | {error, term()}
 when Client :: map(),
      Points :: [Point],
      Point :: #{measurement => atom() | binary() | list(),
@@ -154,7 +154,7 @@ write_async(#{protocol := Protocol} = Client, Key, Points, {ReplayFun, Args}) ->
 -spec(stop_client(Client :: map()) -> ok | term()).
 stop_client(#{pool := Pool, protocol := Protocol}) ->
     case Protocol of
-        http -> 
+        http ->
             ehttpc_sup:stop_pool(Pool);
         udp ->
             ecpool:stop_sup_pool(Pool)
@@ -183,9 +183,9 @@ path(Version, Options) ->
     List = lists:foldl(FoldlFun, [], List0),
     Path = path(Version),
     case length(List) of
-        0 -> 
+        0 ->
             Path;
-        _ -> 
+        _ ->
             Path ++ "?" ++ uri_string:compose_query(List)
     end.
 
@@ -197,7 +197,7 @@ qs_list(v1) ->
         {"precision", precision}
     ];
 qs_list(v2) ->
-    [ 
+    [
         {"org", org},
         {"bucket", bucket},
         {"precision", precision}

--- a/src/influxdb_http.erl
+++ b/src/influxdb_http.erl
@@ -99,7 +99,8 @@ do_write(Worker, {_Path, _Headers, _Data} = Request) ->
     end.
 
 do_aysnc_write(Worker, Request, ReplayFunAndArgs) ->
-    ok = ehttpc:request_async(Worker, post, Request, 5000, ReplayFunAndArgs).
+    ok = ehttpc:request_async(Worker, post, Request, 5000, ReplayFunAndArgs),
+    {ok, Worker}.
 
 pick_worker(#{pool := Pool, pool_type := hash}, Key) ->
     ehttpc_pool:pick_worker(Pool, Key);


### PR DESCRIPTION
This new API return type will allow the caller to monitor the worker PID and decide if a certain inflight request has been lost due to worker death.