### PR TITLE
chore: upgrade to ehttpc 0.4.5 and ecpool 0.5.3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {deps, [
-    {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.4.0"}}},
-    {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.2"}}}
+    {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.4.5"}}},
+    {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.3"}}}
 ]}.
 
 {edoc_opts, [{preprocess, true}]}.

--- a/test/influxdb_SUITE.erl
+++ b/test/influxdb_SUITE.erl
@@ -60,7 +60,7 @@ t_write_(WriteProtocol, PoolType, Version) ->
     PassWord = <<"123qwe">>,
     DataBase = <<"mydb">>,
     Precision = <<"ms">>,
-    Pool = influxdb_test,
+    Pool = <<"influxdb_test">>,
     PoolSize = 16,
     Option = [ {host, Host}
              , {port, Port}


### PR DESCRIPTION
so that pool names don't have to be atoms.