### PR TITLE
feat: add option to return reason when is_alive returns false

### DIFF
--- a/src/influxdb.appup.src
+++ b/src/influxdb.appup.src
@@ -1,10 +1,16 @@
 %% -*- mode: erlang -*-
 {VSN,
  [
+  {"1.1.8", [
+    {load_module, influxdb_line, brutal_purge, soft_purge, []},
+    {load_module, influxdb_http, brutal_purge, soft_purge, []},
+    {load_module, influxdb, brutal_purge, soft_purge, []}
+  ]},
   {"1.1.7", []}, %% no modules changed
   {<<"1\\.1\\.[2-6]">>, [
     {load_module, influxdb_http, brutal_purge, soft_purge, []},
-    {load_module, influxdb, brutal_purge, soft_purge, []}
+    {load_module, influxdb, brutal_purge, soft_purge, []},
+    {load_module, influxdb_line,brutal_purge,soft_purge,[]}
   ]},
   {"1.1.1", [
     {load_module, influxdb_line, brutal_purge, soft_purge, []},
@@ -24,10 +30,16 @@
    {<<".*">>, []}
  ],
  [
+  {"1.1.8", [
+    {load_module, influxdb_line, brutal_purge, soft_purge, []},
+    {load_module, influxdb_http, brutal_purge, soft_purge, []},
+    {load_module, influxdb, brutal_purge, soft_purge, []}
+  ]},
   {"1.1.7", []}, %% no modules changed
   {<<"1\\.1\\.[2-6]">>, [
     {load_module, influxdb_http, brutal_purge, soft_purge, []},
-    {load_module, influxdb, brutal_purge, soft_purge, []}
+    {load_module, influxdb, brutal_purge, soft_purge, []},
+    {load_module, influxdb_line,brutal_purge,soft_purge,[]}
   ]},
   {"1.1.1", [
     {load_module, influxdb_line, brutal_purge, soft_purge, []},

--- a/src/influxdb.erl
+++ b/src/influxdb.erl
@@ -18,6 +18,7 @@
 
 -export([ start_client/1
         , is_alive/1
+        , is_alive/2
         , write/2
         , write/3
         , write_async/3
@@ -57,10 +58,14 @@ start_client(Options0) ->
     end.
 
 -spec(is_alive(Client :: map()) -> true | false).
-is_alive(#{protocol := Protocol} = Client) ->
+is_alive(Client) ->
+    is_alive(Client, false).
+
+-spec(is_alive(Client :: map(), ReturnReason :: boolean()) -> true | false | {false, Reason :: term()}).
+is_alive(#{protocol := Protocol} = Client, ReturnReason) ->
     case Protocol of
         http ->
-            influxdb_http:is_alive(Client);
+            influxdb_http:is_alive(Client, ReturnReason);
         udp ->
             true
     end.

--- a/src/influxdb_http.erl
+++ b/src/influxdb_http.erl
@@ -15,18 +15,18 @@
 %%--------------------------------------------------------------------
 -module(influxdb_http).
 
--export([ is_alive/1
+-export([ is_alive/2
         , write/2
         , write/3
         , write_async/3
         , write_async/4]).
 
-is_alive(Client = #{version := Version}) ->
-    is_alive(Version, Client);
-is_alive(Client) ->
-    is_alive(v1, Client).
+is_alive(Client = #{version := Version}, ReturnReason) ->
+    is_alive(Version, Client, ReturnReason);
+is_alive(Client, ReturnReason) ->
+    is_alive(v1, Client, ReturnReason).
 
-is_alive(v2, Client = #{headers := Headers}) ->
+is_alive(v2, Client = #{headers := Headers}, ReturnReason) ->
     Path = "/ping",
     try
         Worker = pick_worker(Client, ignore),
@@ -39,13 +39,14 @@ is_alive(v2, Client = #{headers := Headers}) ->
                 true;
             {ok, 204, _, _} ->
                 true;
-            _ ->
-                false
+            Return ->
+                maybe_return_reason(Return, ReturnReason)
         end
-    catch _E:_R:_S ->
+    catch E:R:S ->
+        logger:error("[InfluxDB] is alive: ~0p ~0p ~0p", [E, R, S]),
         false
     end;
-is_alive(v1, Client) ->
+is_alive(v1, Client, ReturnReason) ->
     Path = "/ping",
     Headers = [{<<"verbose">>, <<"true">>}],
     try
@@ -55,8 +56,8 @@ is_alive(v1, Client) ->
                 true;
             {ok, 204, _, _} ->
                 true;
-            _ ->
-                false
+            Return ->
+                maybe_return_reason(Return, ReturnReason)
         end
     catch E:R:S ->
         logger:error("[InfluxDB] is alive: ~0p ~0p ~0p", [E, R, S]),
@@ -81,6 +82,15 @@ write_async(Client = #{path := Path, headers := Headers}, Key, Data, ReplayFunAn
 
 %%==============================================================================
 %% Internal funcs
+maybe_return_reason({ok, ReturnCode, _}, true) ->
+    {false, ReturnCode};
+maybe_return_reason({ok, ReturnCode, _, Body}, true) ->
+    {false, {ReturnCode, Body}};
+maybe_return_reason({error, Reason}, true) ->
+    {false, Reason};
+maybe_return_reason(_, _) ->
+    false.
+
 do_write(Worker, {_Path, _Headers, _Data} = Request) ->
     try ehttpc:request(Worker, post, Request) of
         {ok, 204, _} ->

--- a/src/influxdb_http.erl
+++ b/src/influxdb_http.erl
@@ -43,7 +43,7 @@ is_alive(v2, Client = #{headers := Headers}, ReturnReason) ->
                 maybe_return_reason(Return, ReturnReason)
         end
     catch E:R:S ->
-        logger:error("[InfluxDB] is alive: ~0p ~0p ~0p", [E, R, S]),
+        logger:error("[InfluxDB] is_alive exception: ~0p ~0p ~0p", [E, R, S]),
         false
     end;
 is_alive(v1, Client, ReturnReason) ->
@@ -60,7 +60,7 @@ is_alive(v1, Client, ReturnReason) ->
                 maybe_return_reason(Return, ReturnReason)
         end
     catch E:R:S ->
-        logger:error("[InfluxDB] is alive: ~0p ~0p ~0p", [E, R, S]),
+        logger:error("[InfluxDB] is_alive exception: ~0p ~0p ~0p", [E, R, S]),
         false
     end.
 

--- a/test/influxdb_SUITE.erl
+++ b/test/influxdb_SUITE.erl
@@ -107,7 +107,16 @@ t_is_alive_(Version) ->
     timer:sleep(500),
     ?assertEqual(false, influxdb:is_alive(Client1)),
     ?assertEqual({false, econnrefused}, influxdb:is_alive(Client1, true)),
-    ok = influxdb:stop_client(Client1).
+    ok = influxdb:stop_client(Client1),
+
+    {ok, Client2} = influxdb:start_client(Option0),
+    % We remove the pool so that we will cause an exception
+    BadClient = maps:remove(pool, Client2),
+    timer:sleep(500),
+    ?assertEqual(false, influxdb:is_alive(BadClient)),
+    ?assertMatch({false, #{exception := error, reason := function_clause}},
+                 influxdb:is_alive(BadClient, true)),
+    ok = influxdb:stop_client(Client2).
 
 options(Host, Port, WriteProtocol, PoolType, Version) ->
     HttpsEnabled = false,


### PR DESCRIPTION
We want the caller to is_alive to be able to log the reason for why is_alive returns false. This is now possible by calling influx:is_alive(Client, true).