### PR TITLE
feat: supports path option to configure the path of write endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,17 @@ Option = [ {host, "127.0.0.1"}
          , {pool, influxdb_client_pool}
          , {pool_size, 8}
          , {pool_type, random}
+         , {version, v1},
+         , {path, undefined}
          , {username, <<"uname">>}
-         , {password, <<"'pwd'">>}
+         , {password, <<"pwd">>}
          , {database, <<"mydb">>}
          , {precision, <<"ms">>}].
 ```
+
+* The client supports the `v1` and `v2` API versions of InfluxDB. Using `v1` by default, the version automatically chooses the write endpoint path(for `v1`, it's `/write`).
+* The optional `path` option specifies the write endpoint path manually. The other TSDB supporting the InfluxDB writing protocol may have different write endpoint paths. You can configure it with this option.
+
 
 ``` erlang
 %% udp

--- a/src/influxdb.erl
+++ b/src/influxdb.erl
@@ -186,11 +186,7 @@ path(Version, Options) ->
             end
         end,
     List = lists:foldl(FoldlFun, [], List0),
-    Path0 = path(Version),
-    Path = case proplists:get_value(path, Options) of
-               undefined -> Path0;
-               Val -> Val
-           end,
+    Path = proplists:get_value(path, Options, path(Version)),
     case length(List) of
         0 ->
             Path;

--- a/src/influxdb.erl
+++ b/src/influxdb.erl
@@ -186,7 +186,11 @@ path(Version, Options) ->
             end
         end,
     List = lists:foldl(FoldlFun, [], List0),
-    Path = path(Version),
+    Path0 = path(Version),
+    Path = case proplists:get_value(path, Options) of
+               undefined -> Path0;
+               Val -> Val
+           end,
     case length(List) of
         0 ->
             Path;


### PR DESCRIPTION
Hi.

This PR adds an optional option `path` to specify the write endpoint path. 
The other TSDB supporting the InfluxDB writing protocol may have different write endpoint paths. For example, the write endpoint is `/v1/influxdb/write` in [GreptimeDB](https://github.com/GreptimeTeam/greptimedb). Let the user can configure it with this option.

It doesn't break the current API's promise. The `path` is optional.