### PR TITLE
fix: replace SHOW DATABASES with lightweight auth check for health rification

### DIFF
--- a/src/influxdb.erl
+++ b/src/influxdb.erl
@@ -105,53 +105,12 @@ write(#{protocol := Protocol} = Client, Points) ->
     end.
 
 -spec check_auth(Client :: map()) -> ok | {error, not_authorized} | {error, term()}.
-check_auth(#{version := v3} = Client0) ->
-    #{protocol := Protocol, auth_path := AuthPath, opts := Opts} = Client0,
-    Client = Client0#{path := AuthPath},
-    Body = json:encode(#{
-         db => proplists:get_value(database, Opts),
-         q => <<"show tables">>
-     }),
-    Ret =
-        try
-            case Protocol of
-                http ->
-                    influxdb_http:write(Client, Body);
-                udp ->
-                    influxdb_udp:write(Client, Body)
-            end
-        catch E:R:S ->
-            logger:error("[InfluxDB] Check auth ~0p failed: ~0p ~0p ~p", [Body, E, R, S]),
-            {error, {E, R}}
-        end,
-    case Ret of
-        {_, {200, _, _}} -> ok;
-        {_, {404, _, _}} -> ok;
-        {_, {401, _}} -> {error, not_authorized};
-        {_, {401, _, _}} -> {error, not_authorized};
-        {error, Err} -> {error, Err};
-        Err -> {error, Err}
-    end;
-check_auth(#{protocol := Protocol, auth_path := AuthPath} = Client0) ->
-    FakePoint = #{fields => #{<<"check_auth">> => <<"">>}, measurement => <<"check_auth">>},
-    Client = Client0#{path := AuthPath},
-    Ret =
-        try
-            case Protocol of
-                http ->
-                    influxdb_http:write(Client, influxdb_line:encode(FakePoint));
-                udp ->
-                    influxdb_udp:write(Client, influxdb_line:encode(FakePoint))
-            end
-        catch E:R:S ->
-            logger:error("[InfluxDB] Check auth ~0p failed: ~0p ~0p ~p", [FakePoint, E, R, S]),
-            {error, {E, R}}
-        end,
-    case Ret of
-        {_, {200, _, _}} -> ok;
-        {_, {401, _, _}} -> {error, not_authorized};
-        {error, Err} -> {error, Err};
-        Err -> {error, Err}
+check_auth(#{protocol := Protocol} = Client) ->
+    case Protocol of
+        http ->
+            influxdb_http:check_auth(Client);
+        udp ->
+            ok
     end.
 
 -spec(write(Client, Key, Points) -> ok | {error, term()}
@@ -253,10 +212,19 @@ write_path(Version, Options) ->
     RawParams = [],
     path(BasePath, RawParams, Version, Options).
 
-auth_path(Version, Options) ->
-    BasePath = auth_path(Version),
-    RawParams = [{"q", "show databases"}],
-    path(BasePath, RawParams, Version, Options).
+auth_path(v1, Options) ->
+    BasePath = "/query",
+    %% No query parameter — we only need credential validation.
+    %% InfluxDB returns 401 for bad credentials, 400 for missing "q" param
+    %% (which means credentials are valid).
+    RawParams = [],
+    path(BasePath, RawParams, v1, Options);
+auth_path(v2, _Options) ->
+    %% v2/v3 check_auth uses dedicated endpoints in influxdb_http,
+    %% no auth_path needed.
+    undefined;
+auth_path(v3, _Options) ->
+    undefined.
 
 path(BasePath, RawParams, Version, Options) ->
     List0 = qs_list(Version),
@@ -306,9 +274,53 @@ header(v3, Options) ->
     Token = proplists:get_value(token, Options, <<"">>),
     [{<<"Authorization">>, <<"Bearer ", Token/binary>>} | header(v1, Options)].
 
-auth_path(v3) -> "/api/v3/query_sql";
-auth_path(_Version) -> "/query".
 
 str(A) when is_atom(A) -> atom_to_list(A);
 str(B) when is_binary(B) -> binary_to_list(B);
 str(L) when is_list(L) -> L.
+
+%%===================================================================
+%% eunit tests
+%%===================================================================
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+auth_path_v1_no_show_databases_test() ->
+    Options = [{database, "mydb"}, {username, "user"}, {password, "pass"}],
+    Path = auth_path(v1, Options),
+    %% auth_path must NOT contain "show databases" or any "q=" parameter
+    ?assertNotEqual(nomatch, string:find(Path, "/query")),
+    ?assertEqual(nomatch, string:find(Path, "show")),
+    ?assertEqual(nomatch, string:find(Path, "SHOW")),
+    ?assertEqual(nomatch, string:find(Path, "q=")),
+    %% but must contain credential params
+    ?assertNotEqual(nomatch, string:find(Path, "u=user")),
+    ?assertNotEqual(nomatch, string:find(Path, "p=pass")).
+
+auth_path_v2_undefined_test() ->
+    Options = [{token, <<"mytoken">>}, {org, "myorg"}, {bucket, "mybucket"}],
+    ?assertEqual(undefined, auth_path(v2, Options)).
+
+auth_path_v3_undefined_test() ->
+    Options = [{token, <<"mytoken">>}, {database, "mydb"}],
+    ?assertEqual(undefined, auth_path(v3, Options)).
+
+http_clients_options_v1_no_show_databases_test() ->
+    Options = [{version, v1}, {database, "mydb"}, {username, "user"}, {password, "pass"}],
+    #{auth_path := AuthPath} = http_clients_options(Options),
+    ?assertNotEqual(nomatch, string:find(AuthPath, "/query")),
+    ?assertEqual(nomatch, string:find(AuthPath, "show")),
+    ?assertEqual(nomatch, string:find(AuthPath, "q=")).
+
+http_clients_options_v2_auth_path_undefined_test() ->
+    Options = [{version, v2}, {token, <<"tok">>}, {org, "org"}, {bucket, "bkt"}],
+    #{auth_path := AuthPath} = http_clients_options(Options),
+    ?assertEqual(undefined, AuthPath).
+
+http_clients_options_v3_auth_path_undefined_test() ->
+    Options = [{version, v3}, {token, <<"tok">>}, {database, "mydb"}],
+    #{auth_path := AuthPath} = http_clients_options(Options),
+    ?assertEqual(undefined, AuthPath).
+
+-endif.

--- a/src/influxdb_http.erl
+++ b/src/influxdb_http.erl
@@ -16,6 +16,7 @@
 -module(influxdb_http).
 
 -export([ is_alive/2
+        , check_auth/1
         , write/2
         , write/3
         , write_async/3
@@ -64,6 +65,22 @@ is_alive(v1, Client, ReturnReason) ->
                              ReturnReason)
     end.
 
+%% @doc Check authentication against the InfluxDB server.
+%% For v2, uses GET /api/v2/buckets with the Authorization header.
+%% For v3, uses POST /api/v3/query_sql with the Authorization header (empty body).
+%% For v1, uses GET /query (without "q" param) with credentials in query string;
+%%   returns ok on 200 or 400 (missing "q" means auth passed), error on 401.
+-spec check_auth(Client :: map()) -> ok | {error, not_authorized} | {error, term()}.
+check_auth(#{version := v2} = Client) ->
+    check_auth_v2(Client);
+check_auth(#{version := v3} = Client) ->
+    check_auth_v3(Client);
+check_auth(#{version := v1} = Client) ->
+    check_auth_v1(Client);
+check_auth(Client) ->
+    %% default to v1
+    check_auth_v1(Client).
+
 write(Client = #{path := Path, headers := Headers}, Data) ->
     Request = {Path, Headers, Data},
     do_write(pick_worker(Client, ignore), Request).
@@ -82,6 +99,107 @@ write_async(Client = #{path := Path, headers := Headers}, Key, Data, ReplayFunAn
 
 %%==============================================================================
 %% Internal funcs
+
+check_auth_v2(#{headers := Headers} = Client) ->
+    Path = "/api/v2/buckets?limit=1",
+    try
+        Worker = pick_worker(Client, ignore),
+        case ehttpc:request(Worker, get, {Path, Headers}) of
+            {ok, Code, _} when Code >= 200, Code < 300 ->
+                ok;
+            {ok, Code, _, _} when Code >= 200, Code < 300 ->
+                ok;
+            {ok, 401, _} ->
+                {error, not_authorized};
+            {ok, 401, _, _} ->
+                {error, not_authorized};
+            {ok, Code, _} ->
+                {error, {unexpected_status, Code}};
+            {ok, Code, _, Body} ->
+                {error, {unexpected_status, Code, Body}};
+            {error, Reason} ->
+                {error, Reason}
+        end
+    catch E:R:S ->
+        logger:error("[InfluxDB] check_auth v2 exception: ~0p ~0p ~0p", [E, R, S]),
+        {error, {E, R}}
+    end.
+
+check_auth_v3(#{headers := Headers} = Client) ->
+    %% POST /api/v3/query_sql with empty body.
+    %% InfluxDB v3 authenticates first, then validates the request:
+    %%   - 401: token is invalid
+    %%   - 400/422: token is valid but request is malformed (no query body)
+    %%   - 200: token is valid (unlikely for empty body, but accept it)
+    Path = "/api/v3/query_sql",
+    try
+        Worker = pick_worker(Client, ignore),
+        case ehttpc:request(Worker, post, {Path, Headers, <<>>}) of
+            {ok, Code, _} when Code >= 200, Code < 300 ->
+                ok;
+            {ok, Code, _, _} when Code >= 200, Code < 300 ->
+                ok;
+            {ok, 400, _} ->
+                ok;
+            {ok, 400, _, _} ->
+                ok;
+            {ok, 422, _} ->
+                ok;
+            {ok, 422, _, _} ->
+                ok;
+            {ok, 401, _} ->
+                {error, not_authorized};
+            {ok, 401, _, _} ->
+                {error, not_authorized};
+            {ok, Code, _} ->
+                {error, {unexpected_status, Code}};
+            {ok, Code, _, Body} ->
+                {error, {unexpected_status, Code, Body}};
+            {error, Reason} ->
+                {error, Reason}
+        end
+    catch E:R:S ->
+        logger:error("[InfluxDB] check_auth v3 exception: ~0p ~0p ~0p", [E, R, S]),
+        {error, {E, R}}
+    end.
+
+check_auth_v1(#{auth_path := AuthPath, headers := Headers} = Client) ->
+    %% Send GET /query with credentials but without "q" parameter.
+    %% InfluxDB v1 authenticates the request first, then checks for "q":
+    %%   - 401: credentials are invalid
+    %%   - 400 (missing "q"): credentials are valid
+    %%   - 200: credentials are valid (auth disabled on server)
+    try
+        Worker = pick_worker(Client, ignore),
+        case ehttpc:request(Worker, get, {AuthPath, Headers}) of
+            {ok, 200, _} ->
+                ok;
+            {ok, 200, _, _} ->
+                ok;
+            {ok, 400, _, _} ->
+                %% "missing required parameter q" — auth passed
+                ok;
+            {ok, 400, _} ->
+                ok;
+            {ok, 401, _} ->
+                {error, not_authorized};
+            {ok, 401, _, _} ->
+                {error, not_authorized};
+            {ok, Code, _} ->
+                {error, {unexpected_status, Code}};
+            {ok, Code, _, Body} ->
+                {error, {unexpected_status, Code, Body}};
+            {error, Reason} ->
+                {error, Reason}
+        end
+    catch E:R:S ->
+        logger:error("[InfluxDB] check_auth v1 exception: ~0p ~0p ~0p", [E, R, S]),
+        {error, {E, R}}
+    end;
+check_auth_v1(_Client) ->
+    %% No auth_path available, skip auth check
+    ok.
+
 maybe_return_reason({ok, ReturnCode, _}, true) ->
     {false, ReturnCode};
 maybe_return_reason({ok, ReturnCode, _, Body}, true) ->

--- a/test/influxdb_SUITE.erl
+++ b/test/influxdb_SUITE.erl
@@ -10,6 +10,7 @@ all() -> [ t_encode_line
          , t_write
          , t_is_alive
          , t_check_auth
+         , t_check_auth_no_show_databases
          ].
 
 init_per_suite(Config) ->
@@ -232,3 +233,41 @@ v3_token(UseTLS) ->
     {ok, Raw} = file:read_file(Path),
     #{<<"token">> := Token} = json:decode(Raw),
     Token.
+
+%% Verify that check_auth does NOT use "SHOW DATABASES" for health checks.
+%% This is critical because some security audit systems flag "SHOW DATABASES"
+%% as a penetration attack.
+t_check_auth_no_show_databases(_) ->
+    t_check_auth_no_show_databases_(v1),
+    t_check_auth_no_show_databases_(v2).
+
+t_check_auth_no_show_databases_(Version) ->
+    application:ensure_all_started(influxdb),
+    Host = os:getenv("INFLUX_TCP_HOST", "influxdb_tcp"),
+    Port = 8086,
+    Option = options(Host, Port, http, random, Version),
+    {ok, Client} = influxdb:start_client(Option),
+    try
+        %% Verify auth_path in the Client map does not contain "show databases"
+        case maps:find(auth_path, Client) of
+            {ok, undefined} ->
+                %% v2: auth_path should be undefined
+                ?assertEqual(v2, Version);
+            {ok, AuthPath} when is_list(AuthPath) ->
+                %% v1: auth_path must not contain "show" or "q=" query param
+                LowerPath = string:lowercase(AuthPath),
+                ?assertEqual(nomatch, string:find(LowerPath, "show"),
+                             "auth_path must not contain SHOW DATABASES"),
+                ?assertEqual(nomatch, string:find(LowerPath, "q="),
+                             "auth_path must not contain q= parameter"),
+                %% Should still be a /query path (for credential validation)
+                ?assertNotEqual(nomatch, string:find(LowerPath, "/query"));
+            error ->
+                %% auth_path key not present — acceptable
+                ok
+        end,
+        %% Verify check_auth still works correctly
+        ?assertEqual(ok, influxdb:check_auth(Client))
+    after
+        influxdb:stop_client(Client)
+    end.


### PR DESCRIPTION
Replace the SHOW DATABASES / show tables based auth check with lightweight, non-query alternatives to avoid triggering security audit alerts:

- v1: GET /query without "q" param (401=bad creds, 400=good creds)
- v2: GET /api/v2/buckets?limit=1 with Authorization header
- v3: POST /api/v3/query_sql with empty body and Authorization header

Move check_auth logic from influxdb.erl to influxdb_http.erl with per-version dispatch. Add eunit and CT tests to verify no SHOW statements are used.