### PR TITLE
Add opt-in auth for ping checks across versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ _build/
 rebar.lock
 rebar3.crashdump
 data/
-.omx/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _build/
 rebar.lock
 rebar3.crashdump
 data/
+.omx/

--- a/include/influxdb.hrl
+++ b/include/influxdb.hrl
@@ -25,6 +25,7 @@
                   | {database, string()}
                   | {username, string()}
                   | {password, string()}
+                  | {ping_with_auth, boolean()}
                   | {precision, precision()}
                   | {https_enabled, boolean()}
                   | {ssl, ssloptions()}.

--- a/src/influxdb.erl
+++ b/src/influxdb.erl
@@ -333,11 +333,11 @@ v1_ping_auth_params_enabled_test() ->
     ?assertEqual(nomatch, string:find(PingParams, "precision=")).
 
 v2_ping_auth_params_ignored_test() ->
-    Options = [{version, v2}, {token, <<"tok">>}, {ping_with_auth, true}],
+    Options = [{version, v2}, {token, <<"tok">>}],
     ?assertEqual([], influxdb_http:ping_auth_params(Options)).
 
 v3_ping_auth_params_ignored_test() ->
-    Options = [{version, v3}, {token, <<"tok">>}, {database, "mydb"}, {ping_with_auth, true}],
+    Options = [{version, v3}, {token, <<"tok">>}, {database, "mydb"}],
     ?assertEqual([], influxdb_http:ping_auth_params(Options)).
 
 v1_is_alive_with_ping_auth_enabled_test() ->
@@ -415,7 +415,29 @@ v1_is_alive_rejects_bad_ping_auth_when_enabled_test() ->
         ok = influxdb:stop_client(Client)
     end.
 
-v2_is_alive_ignores_ping_with_auth_test() ->
+v2_is_alive_defaults_to_ping_without_auth_test() ->
+    application:ensure_all_started(influxdb),
+    ListenSocket = auth_header_ping_server_start(undefined),
+    {ok, {_Addr, Port}} = inet:sockname(ListenSocket),
+    Options =
+        [ {host, "127.0.0.1"}
+        , {port, Port}
+        , {protocol, http}
+        , {https_enabled, false}
+        , {pool, pool_name("v2_ping_no_header")}
+        , {pool_size, 1}
+        , {pool_type, random}
+        , {token, <<"tok">>}
+        , {version, v2}
+        ],
+    {ok, Client} = influxdb:start_client(Options),
+    try
+        ?assertEqual(true, influxdb:is_alive(Client))
+    after
+        ok = influxdb:stop_client(Client)
+    end.
+
+v2_is_alive_with_ping_auth_enabled_test() ->
     application:ensure_all_started(influxdb),
     ListenSocket = auth_header_ping_server_start(<<"Authorization: Token tok\r\n">>),
     {ok, {_Addr, Port}} = inet:sockname(ListenSocket),
@@ -438,7 +460,30 @@ v2_is_alive_ignores_ping_with_auth_test() ->
         ok = influxdb:stop_client(Client)
     end.
 
-v3_is_alive_ignores_ping_with_auth_test() ->
+v3_is_alive_defaults_to_ping_without_auth_test() ->
+    application:ensure_all_started(influxdb),
+    ListenSocket = auth_header_ping_server_start(undefined),
+    {ok, {_Addr, Port}} = inet:sockname(ListenSocket),
+    Options =
+        [ {host, "127.0.0.1"}
+        , {port, Port}
+        , {protocol, http}
+        , {https_enabled, false}
+        , {pool, pool_name("v3_ping_no_header")}
+        , {pool_size, 1}
+        , {pool_type, random}
+        , {token, <<"tok">>}
+        , {database, <<"mydb">>}
+        , {version, v3}
+        ],
+    {ok, Client} = influxdb:start_client(Options),
+    try
+        ?assertEqual(true, influxdb:is_alive(Client))
+    after
+        ok = influxdb:stop_client(Client)
+    end.
+
+v3_is_alive_with_ping_auth_enabled_test() ->
     application:ensure_all_started(influxdb),
     ListenSocket = auth_header_ping_server_start(<<"Authorization: Bearer tok\r\n">>),
     {ok, {_Addr, Port}} = inet:sockname(ListenSocket),
@@ -498,13 +543,19 @@ auth_header_ping_server_serve(ListenSocket, ExpectedHeader) ->
     {ok, Socket} = gen_tcp:accept(ListenSocket),
     {ok, Request} = gen_tcp:recv(Socket, 0, 5000),
     StatusLine =
-        case contains(Request, <<"GET /ping HTTP/">>) andalso contains_ci(Request, ExpectedHeader) of
+        case auth_header_ping_request_result(Request, ExpectedHeader) of
             true -> <<"HTTP/1.1 204 No Content\r\n">>;
             false -> <<"HTTP/1.1 401 Unauthorized\r\n">>
         end,
     ok = gen_tcp:send(Socket, [StatusLine, <<"Content-Length: 0\r\nConnection: close\r\n\r\n">>]),
     ok = gen_tcp:close(Socket),
     ok = gen_tcp:close(ListenSocket).
+
+auth_header_ping_request_result(Request, undefined) ->
+    contains(Request, <<"GET /ping HTTP/">>) andalso
+        not contains_ci(Request, <<"authorization: ">>);
+auth_header_ping_request_result(Request, ExpectedHeader) ->
+    contains(Request, <<"GET /ping HTTP/">>) andalso contains_ci(Request, ExpectedHeader).
 
 ping_auth_request_result(Request, undefined, undefined) ->
     contains(Request, <<"GET /ping HTTP/">>);

--- a/src/influxdb.erl
+++ b/src/influxdb.erl
@@ -313,6 +313,155 @@ http_clients_options_v1_no_show_databases_test() ->
     ?assertEqual(nomatch, string:find(AuthPath, "show")),
     ?assertEqual(nomatch, string:find(AuthPath, "q=")).
 
+v1_ping_auth_params_default_disabled_test() ->
+    Options = [{version, v1}, {database, "mydb"}, {username, "user"}, {password, "pass"}],
+    PingParams = influxdb_http:ping_auth_params(Options),
+    #{path := WritePath, auth_path := AuthPath} = http_clients_options(Options),
+    ?assertEqual([], PingParams),
+    ?assertNotEqual(nomatch, string:find(WritePath, "/write")),
+    ?assertNotEqual(nomatch, string:find(WritePath, "db=mydb")),
+    ?assertNotEqual(nomatch, string:find(AuthPath, "/query")).
+
+v1_ping_auth_params_enabled_test() ->
+    Options =
+        [{version, v1}, {database, "mydb"}, {username, "user"}, {password, "pass"}, {ping_with_auth, true}],
+    PingParams = influxdb_http:ping_auth_params(Options),
+    ?assertNotEqual(nomatch, string:find(PingParams, "verbose=true")),
+    ?assertNotEqual(nomatch, string:find(PingParams, "u=user")),
+    ?assertNotEqual(nomatch, string:find(PingParams, "p=pass")),
+    ?assertEqual(nomatch, string:find(PingParams, "db=mydb")),
+    ?assertEqual(nomatch, string:find(PingParams, "precision=")).
+
+v2_ping_auth_params_ignored_test() ->
+    Options = [{version, v2}, {token, <<"tok">>}, {ping_with_auth, true}],
+    ?assertEqual([], influxdb_http:ping_auth_params(Options)).
+
+v3_ping_auth_params_ignored_test() ->
+    Options = [{version, v3}, {token, <<"tok">>}, {database, "mydb"}, {ping_with_auth, true}],
+    ?assertEqual([], influxdb_http:ping_auth_params(Options)).
+
+v1_is_alive_with_ping_auth_enabled_test() ->
+    application:ensure_all_started(influxdb),
+    ListenSocket = ping_auth_server_start(<<"user">>, <<"pass">>),
+    {ok, {_Addr, Port}} = inet:sockname(ListenSocket),
+    Options =
+        [ {host, "127.0.0.1"}
+        , {port, Port}
+        , {protocol, http}
+        , {https_enabled, false}
+        , {pool, pool_name("ping_auth_good")}
+        , {pool_size, 1}
+        , {pool_type, random}
+        , {username, <<"user">>}
+        , {password, <<"pass">>}
+        , {database, <<"mydb">>}
+        , {ping_with_auth, true}
+        , {version, v1}
+        ],
+    {ok, Client} = influxdb:start_client(Options),
+    try
+        ?assertEqual(true, influxdb:is_alive(Client))
+    after
+        ok = influxdb:stop_client(Client)
+        end.
+
+v1_is_alive_defaults_to_legacy_ping_test() ->
+    application:ensure_all_started(influxdb),
+    ListenSocket = ping_auth_server_start(undefined, undefined),
+    {ok, {_Addr, Port}} = inet:sockname(ListenSocket),
+    Options =
+        [ {host, "127.0.0.1"}
+        , {port, Port}
+        , {protocol, http}
+        , {https_enabled, false}
+        , {pool, pool_name("ping_legacy")}
+        , {pool_size, 1}
+        , {pool_type, random}
+        , {username, <<"user">>}
+        , {password, <<"pass">>}
+        , {database, <<"mydb">>}
+        , {version, v1}
+        ],
+    {ok, Client} = influxdb:start_client(Options),
+    try
+        ?assertEqual(true, influxdb:is_alive(Client))
+    after
+        ok = influxdb:stop_client(Client)
+    end.
+
+v1_is_alive_rejects_bad_ping_auth_when_enabled_test() ->
+    application:ensure_all_started(influxdb),
+    ListenSocket = ping_auth_server_start(<<"user">>, <<"pass">>),
+    {ok, {_Addr, Port}} = inet:sockname(ListenSocket),
+    Options =
+        [ {host, "127.0.0.1"}
+        , {port, Port}
+        , {protocol, http}
+        , {https_enabled, false}
+        , {pool, pool_name("ping_auth_bad")}
+        , {pool_size, 1}
+        , {pool_type, random}
+        , {username, <<"user">>}
+        , {password, <<"wrong">>}
+        , {database, <<"mydb">>}
+        , {ping_with_auth, true}
+        , {version, v1}
+        ],
+    {ok, Client} = influxdb:start_client(Options),
+    try
+        ?assertMatch({false, _}, influxdb:is_alive(Client, true)),
+        ?assertEqual(false, influxdb:is_alive(Client))
+    after
+        ok = influxdb:stop_client(Client)
+    end.
+
+v2_is_alive_ignores_ping_with_auth_test() ->
+    application:ensure_all_started(influxdb),
+    ListenSocket = auth_header_ping_server_start(<<"Authorization: Token tok\r\n">>),
+    {ok, {_Addr, Port}} = inet:sockname(ListenSocket),
+    Options =
+        [ {host, "127.0.0.1"}
+        , {port, Port}
+        , {protocol, http}
+        , {https_enabled, false}
+        , {pool, pool_name("v2_ping_header")}
+        , {pool_size, 1}
+        , {pool_type, random}
+        , {token, <<"tok">>}
+        , {ping_with_auth, true}
+        , {version, v2}
+        ],
+    {ok, Client} = influxdb:start_client(Options),
+    try
+        ?assertEqual(true, influxdb:is_alive(Client))
+    after
+        ok = influxdb:stop_client(Client)
+    end.
+
+v3_is_alive_ignores_ping_with_auth_test() ->
+    application:ensure_all_started(influxdb),
+    ListenSocket = auth_header_ping_server_start(<<"Authorization: Bearer tok\r\n">>),
+    {ok, {_Addr, Port}} = inet:sockname(ListenSocket),
+    Options =
+        [ {host, "127.0.0.1"}
+        , {port, Port}
+        , {protocol, http}
+        , {https_enabled, false}
+        , {pool, pool_name("v3_ping_header")}
+        , {pool_size, 1}
+        , {pool_type, random}
+        , {token, <<"tok">>}
+        , {database, <<"mydb">>}
+        , {ping_with_auth, true}
+        , {version, v3}
+        ],
+    {ok, Client} = influxdb:start_client(Options),
+    try
+        ?assertEqual(true, influxdb:is_alive(Client))
+    after
+        ok = influxdb:stop_client(Client)
+    end.
+
 http_clients_options_v2_auth_path_undefined_test() ->
     Options = [{version, v2}, {token, <<"tok">>}, {org, "org"}, {bucket, "bkt"}],
     #{auth_path := AuthPath} = http_clients_options(Options),
@@ -322,5 +471,58 @@ http_clients_options_v3_auth_path_undefined_test() ->
     Options = [{version, v3}, {token, <<"tok">>}, {database, "mydb"}],
     #{auth_path := AuthPath} = http_clients_options(Options),
     ?assertEqual(undefined, AuthPath).
+
+ping_auth_server_start(ExpectedUser, ExpectedPassword) ->
+    {ok, ListenSocket} = gen_tcp:listen(0, [binary, {active, false}, {reuseaddr, true}]),
+    spawn_link(fun() -> ping_auth_server_serve(ListenSocket, ExpectedUser, ExpectedPassword) end),
+    ListenSocket.
+
+auth_header_ping_server_start(ExpectedHeader) ->
+    {ok, ListenSocket} = gen_tcp:listen(0, [binary, {active, false}, {reuseaddr, true}]),
+    spawn_link(fun() -> auth_header_ping_server_serve(ListenSocket, ExpectedHeader) end),
+    ListenSocket.
+
+ping_auth_server_serve(ListenSocket, ExpectedUser, ExpectedPassword) ->
+    {ok, Socket} = gen_tcp:accept(ListenSocket),
+    {ok, Request} = gen_tcp:recv(Socket, 0, 5000),
+    StatusLine =
+        case ping_auth_request_result(Request, ExpectedUser, ExpectedPassword) of
+            true -> <<"HTTP/1.1 204 No Content\r\n">>;
+            false -> <<"HTTP/1.1 401 Unauthorized\r\n">>
+        end,
+    ok = gen_tcp:send(Socket, [StatusLine, <<"Content-Length: 0\r\nConnection: close\r\n\r\n">>]),
+    ok = gen_tcp:close(Socket),
+    ok = gen_tcp:close(ListenSocket).
+
+auth_header_ping_server_serve(ListenSocket, ExpectedHeader) ->
+    {ok, Socket} = gen_tcp:accept(ListenSocket),
+    {ok, Request} = gen_tcp:recv(Socket, 0, 5000),
+    StatusLine =
+        case contains(Request, <<"GET /ping HTTP/">>) andalso contains_ci(Request, ExpectedHeader) of
+            true -> <<"HTTP/1.1 204 No Content\r\n">>;
+            false -> <<"HTTP/1.1 401 Unauthorized\r\n">>
+        end,
+    ok = gen_tcp:send(Socket, [StatusLine, <<"Content-Length: 0\r\nConnection: close\r\n\r\n">>]),
+    ok = gen_tcp:close(Socket),
+    ok = gen_tcp:close(ListenSocket).
+
+ping_auth_request_result(Request, undefined, undefined) ->
+    contains(Request, <<"GET /ping HTTP/">>);
+ping_auth_request_result(Request, ExpectedUser, ExpectedPassword) ->
+    contains(Request, <<"GET /ping?">>) andalso
+        contains(Request, <<"verbose=true">>) andalso
+        contains(Request, <<"u=", ExpectedUser/binary>>) andalso
+        contains(Request, <<"p=", ExpectedPassword/binary>>).
+
+contains(Binary, Pattern) ->
+    binary:match(Binary, Pattern) =/= nomatch.
+
+contains_ci(Binary, Pattern) ->
+    LowerBinary = string:lowercase(binary_to_list(Binary)),
+    LowerPattern = string:lowercase(binary_to_list(Pattern)),
+    string:find(LowerBinary, LowerPattern) =/= nomatch.
+
+pool_name(Prefix) ->
+    list_to_binary(Prefix ++ "_" ++ integer_to_list(erlang:unique_integer([positive]))).
 
 -endif.

--- a/src/influxdb_http.erl
+++ b/src/influxdb_http.erl
@@ -31,8 +31,9 @@ is_alive(Client = #{version := Version}, ReturnReason) ->
 is_alive(Client, ReturnReason) ->
     is_alive(v1, Client, ReturnReason).
 
-is_alive(V, Client = #{headers := Headers}, ReturnReason) when V == v2; V == v3 ->
+is_alive(V, Client, ReturnReason) when V == v2; V == v3 ->
     Path = "/ping",
+    Headers = ping_headers(Client),
     try
         Worker = pick_worker(Client, ignore),
         case ehttpc:request(Worker, get, {Path, Headers}) of
@@ -250,7 +251,7 @@ v1_ping_path(_Client) ->
     "/ping".
 
 ping_auth_params(Options) ->
-    case ping_with_auth_enabled(Options) of
+    case ping_query_auth_enabled(Options) of
         true ->
             uri_string:compose_query(
                 lists:reverse(
@@ -263,9 +264,22 @@ ping_auth_params(Options) ->
             []
     end.
 
-ping_with_auth_enabled(Options) ->
+ping_query_auth_enabled(Options) ->
     proplists:get_value(version, Options, v1) =:= v1 andalso
-        proplists:get_value(ping_with_auth, Options, false) =:= true.
+        ping_with_auth_enabled(Options).
+
+ping_with_auth_enabled(Options) ->
+    proplists:get_value(ping_with_auth, Options, false) =:= true.
+
+ping_headers(#{headers := Headers, opts := Options}) ->
+    case ping_with_auth_enabled(Options) of
+        true ->
+            Headers;
+        false ->
+            lists:keydelete(<<"Authorization">>, 1, Headers)
+    end;
+ping_headers(#{headers := Headers}) ->
+    Headers.
 
 add_query_param(Key, Name, Acc, Options) ->
     case proplists:get_value(Key, Options) of

--- a/src/influxdb_http.erl
+++ b/src/influxdb_http.erl
@@ -22,6 +22,10 @@
         , write_async/3
         , write_async/4]).
 
+-ifdef(TEST).
+-export([ping_auth_params/1]).
+-endif.
+
 is_alive(Client = #{version := Version}, ReturnReason) ->
     is_alive(Version, Client, ReturnReason);
 is_alive(Client, ReturnReason) ->
@@ -48,7 +52,7 @@ is_alive(V, Client = #{headers := Headers}, ReturnReason) when V == v2; V == v3 
                              ReturnReason)
     end;
 is_alive(v1, Client, ReturnReason) ->
-    Path = "/ping",
+    Path = v1_ping_path(Client),
     Headers = [{<<"verbose">>, <<"true">>}],
     try
         Worker = pick_worker(Client, ignore),
@@ -235,6 +239,41 @@ do_write(Worker, {_Path, _Headers, _Data} = Request) ->
 do_aysnc_write(Worker, Request, ReplayFunAndArgs) ->
     ok = ehttpc:request_async(Worker, post, Request, 5000, ReplayFunAndArgs),
     {ok, Worker}.
+
+v1_ping_path(#{opts := Options}) ->
+    Params = ping_auth_params(Options),
+    case Params of
+        [] -> "/ping";
+        _ -> "/ping?" ++ Params
+    end;
+v1_ping_path(_Client) ->
+    "/ping".
+
+ping_auth_params(Options) ->
+    case ping_with_auth_enabled(Options) of
+        true ->
+            uri_string:compose_query(
+                lists:reverse(
+                    add_query_param(password, "p",
+                        add_query_param(username, "u", [{"verbose", "true"}], Options),
+                    Options)
+                )
+            );
+        false ->
+            []
+    end.
+
+ping_with_auth_enabled(Options) ->
+    proplists:get_value(version, Options, v1) =:= v1 andalso
+        proplists:get_value(ping_with_auth, Options, false) =:= true.
+
+add_query_param(Key, Name, Acc, Options) ->
+    case proplists:get_value(Key, Options) of
+        undefined -> Acc;
+        Val when is_binary(Val) -> [{Name, binary_to_list(Val)} | Acc];
+        Val when is_list(Val) -> [{Name, Val} | Acc];
+        Val when is_atom(Val) -> [{Name, atom_to_list(Val)} | Acc]
+    end.
 
 pick_worker(#{pool := Pool, pool_type := hash}, Key) ->
     ehttpc_pool:pick_worker(Pool, Key);

--- a/test/influxdb_SUITE.erl
+++ b/test/influxdb_SUITE.erl
@@ -208,6 +208,7 @@ options(Host, Port, WriteProtocol, PoolType, Version) when Version =:= v3 ->
     , {pool_size, PoolSize}
     , {pool_type, PoolType}
     , {token, Token}
+    , {ping_with_auth, true}
     , {database, Database}
     , {precision, Precision}
     , {version, Version}


### PR DESCRIPTION
## Summary

This PR adds an opt-in `{ping_with_auth, true}` HTTP option for authenticated ping checks and applies it consistently across all supported HTTP API versions.

- Keep authenticated ping disabled by default for all versions.
- For v1, enable authenticated ping by adding `u/p` query credentials to `/ping`.
- For v2, enable authenticated ping by keeping the existing `Authorization: Token <token>` header on `/ping`.
- For v3, enable authenticated ping by keeping the existing `Authorization: Bearer <token>` header on `/ping`.
- Leave `write` and `check_auth` behavior unchanged.
- Add regression coverage for default-disabled behavior, opt-in behavior, and version compatibility.
- Update the v3 Common Test fixture to explicitly enable `ping_with_auth` because that integration service requires authenticated ping.

Behavior after this patch:

- Default behavior:
  - v1: `GET /ping`
  - v2: `GET /ping`
  - v3: `GET /ping`
- With `{ping_with_auth, true}`:
  - v1: `GET /ping?verbose=true&u=<username>&p=<password>`
  - v2: `GET /ping` with `Authorization: Token <token>`
  - v3: `GET /ping` with `Authorization: Bearer <token>`

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (not applicable in this repository)
- [x] Schema changes are backward compatible or intentionally breaking (this change is backward compatible; authenticated ping is opt-in)

## Test Plan
- [x] `make eunit` — 17 tests, 0 failures
- [x] `make xref`
- [x] CI `run_test_cases (2.5.0)` — passing
- [x] Manual real-service check against `influxdb:2` for:
  - v1 with `ping_with_auth` disabled
  - v1 with `ping_with_auth` enabled
  - v2 with `ping_with_auth` disabled
  - v2 with `ping_with_auth` enabled
- [x] Mock-based regression tests for v3 with `ping_with_auth` disabled and enabled
