### PR TITLE
Add v1 auth transport option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Option = [ {host, "127.0.0.1"}
 * The client supports the `v1` and `v2` API versions of InfluxDB. Using `v1` by default, the version automatically chooses the write endpoint path(for `v1`, it's `/write`).
 * The optional `path` option specifies the write endpoint path manually. The other TSDB supporting the InfluxDB writing protocol may have different write endpoint paths. You can configure it with this option.
 * For `v1`, when `username` and/or `password` are provided, the client sends them through the `Authorization: Basic ...` header instead of putting them in the URL query string. This also applies to `ping_with_auth`.
+* For `v1` databases that require URL credentials, set `{v1_auth_transport, query_string}` to send `username` and `password` as `u` and `p` query parameters. The default is `{v1_auth_transport, header}`.
 
 
 ``` erlang

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Option = [ {host, "127.0.0.1"}
 
 * The client supports the `v1` and `v2` API versions of InfluxDB. Using `v1` by default, the version automatically chooses the write endpoint path(for `v1`, it's `/write`).
 * The optional `path` option specifies the write endpoint path manually. The other TSDB supporting the InfluxDB writing protocol may have different write endpoint paths. You can configure it with this option.
-* For `v1`, when `username` and/or `password` are provided, the client sends them through the `Authorization: Basic ...` header instead of putting them in the URL query string. This also applies to `ping_with_auth`.
-* For `v1` databases that require URL credentials, set `{v1_auth_transport, query_string}` to send `username` and `password` as `u` and `p` query parameters. The default is `{v1_auth_transport, header}`.
+* For `v1`, when `username` and/or `password` are provided, the client uses the `Authorization: Basic ...` header by default rather than putting them in the URL query string. This also applies to `ping_with_auth`.
+* If a `v1` database requires URL credentials instead, set `{v1_auth_transport, query_string}` to opt in to sending `username` and `password` as `u` and `p` query parameters. The default is `{v1_auth_transport, header}`.
 
 
 ``` erlang

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Option = [ {host, "127.0.0.1"}
 * The optional `path` option specifies the write endpoint path manually. The other TSDB supporting the InfluxDB writing protocol may have different write endpoint paths. You can configure it with this option.
 * For `v1`, when `username` and/or `password` are provided, the client uses the `Authorization: Basic ...` header by default rather than putting them in the URL query string. This also applies to `ping_with_auth`.
 * If a `v1` database requires URL credentials instead, set `{v1_auth_transport, query_string}` to opt in to sending `username` and `password` as `u` and `p` query parameters. The default is `{v1_auth_transport, header}`.
+* Security note: sending credentials in the URL query string is less safe than using the `Authorization` header because URLs may be captured by access logs, proxies, caches, and error reporting systems. Prefer `{v1_auth_transport, header}` whenever possible, and enable TLS (`{https_enabled, true}`) when credentials are sent over the network.
 
 
 ``` erlang

--- a/include/influxdb.hrl
+++ b/include/influxdb.hrl
@@ -21,11 +21,13 @@
                  | {port, inet:port_number()}.
 -type http_opts() :: [http_opt()].
 -type option_text() :: string() | binary() | atom().
+-type v1_auth_transport() :: header | query_string.
 -type http_opt() :: {host, inet:hostname()}
                   | {port, inet:port_number()}
                   | {database, option_text()}
                   | {username, option_text()}
                   | {password, option_text()}
+                  | {v1_auth_transport, v1_auth_transport()}
                   | {ping_with_auth, boolean()}
                   | {precision, precision()}
                   | {https_enabled, boolean()}

--- a/src/influxdb.erl
+++ b/src/influxdb.erl
@@ -227,7 +227,7 @@ auth_path(v3, _Options) ->
     undefined.
 
 path(BasePath, RawParams, Version, Options) ->
-    List0 = qs_list(Version),
+    List0 = qs_list(Version, Options),
     FoldlFun =
         fun({K1, K2}, Acc) ->
             case proplists:get_value(K2, Options) of
@@ -243,18 +243,25 @@ path(BasePath, RawParams, Version, Options) ->
             BasePath ++ "?" ++ uri_string:compose_query(List)
     end.
 
-qs_list(v1) ->
-    [
-        {"db", database},
-        {"precision", precision}
-    ];
-qs_list(v2) ->
+qs_list(v1, Options) ->
+    BaseParams =
+        [
+            {"db", database},
+            {"precision", precision}
+        ],
+    case v1_auth_transport(Options) of
+        query_string ->
+            BaseParams ++ [{"u", username}, {"p", password}];
+        header ->
+            BaseParams
+    end;
+qs_list(v2, _Options) ->
     [
         {"org", org},
         {"bucket", bucket},
         {"precision", precision}
     ];
-qs_list(v3) ->
+qs_list(v3, _Options) ->
     [
         {"db", database}
     ].
@@ -264,10 +271,11 @@ write_path(v2) -> "/api/v2/write";
 write_path(v3) -> "/api/v3/write_lp".
 
 header(v1, Options) ->
-    maybe_add_basic_auth_header(
-        [{<<"Content-type">>, <<"text/plain; charset=utf-8">>}],
-        Options
-    );
+    Headers = [{<<"Content-type">>, <<"text/plain; charset=utf-8">>}],
+    case v1_auth_transport(Options) of
+        header -> maybe_add_basic_auth_header(Headers, Options);
+        query_string -> Headers
+    end;
 header(v2, Options) ->
     Token = proplists:get_value(token, Options, <<"">>),
     [{<<"Authorization">>, <<"Token ", Token/binary>>}, {<<"Content-type">>, <<"text/plain; charset=utf-8">>}];
@@ -303,6 +311,9 @@ to_binary(Value) when is_atom(Value) -> atom_to_binary(Value, utf8).
 
 to_binary_or_empty(undefined) -> <<>>;
 to_binary_or_empty(Value) -> to_binary(Value).
+
+v1_auth_transport(Options) ->
+    proplists:get_value(v1_auth_transport, Options, header).
 
 %%===================================================================
 %% eunit tests
@@ -348,6 +359,24 @@ v1_paths_do_not_include_ping_auth_params_test() ->
     ?assertNotEqual(nomatch, string:find(AuthPath, "/query")),
     ?assertEqual(nomatch, string:find(AuthPath, "u=")),
     ?assertEqual(nomatch, string:find(AuthPath, "p=")).
+
+v1_query_string_auth_transport_uses_url_credentials_test() ->
+    Options =
+        [ {version, v1}
+        , {database, "mydb"}
+        , {username, "user"}
+        , {password, "pass"}
+        , {v1_auth_transport, query_string}
+        ],
+    #{path := WritePath, auth_path := AuthPath, headers := Headers} = http_clients_options(Options),
+    ?assertNotEqual(nomatch, string:find(WritePath, "/write")),
+    ?assertNotEqual(nomatch, string:find(WritePath, "db=mydb")),
+    ?assertNotEqual(nomatch, string:find(WritePath, "u=user")),
+    ?assertNotEqual(nomatch, string:find(WritePath, "p=pass")),
+    ?assertNotEqual(nomatch, string:find(AuthPath, "/query")),
+    ?assertNotEqual(nomatch, string:find(AuthPath, "u=user")),
+    ?assertNotEqual(nomatch, string:find(AuthPath, "p=pass")),
+    ?assertNot(lists:keymember(<<"Authorization">>, 1, Headers)).
 
 v1_header_uses_basic_auth_test() ->
     Options = [{username, <<"user">>}, {password, <<"pass">>}],
@@ -483,6 +512,32 @@ v1_is_alive_rejects_bad_ping_auth_when_enabled_test() ->
         ok = influxdb:stop_client(Client)
     end.
 
+v1_is_alive_with_ping_query_string_auth_enabled_test() ->
+    application:ensure_all_started(influxdb),
+    ListenSocket = ping_query_auth_server_start(<<"user">>, <<"pass">>),
+    {ok, {_Addr, Port}} = inet:sockname(ListenSocket),
+    Options =
+        [ {host, "127.0.0.1"}
+        , {port, Port}
+        , {protocol, http}
+        , {https_enabled, false}
+        , {pool, pool_name("ping_query_auth")}
+        , {pool_size, 1}
+        , {pool_type, random}
+        , {username, <<"user">>}
+        , {password, <<"pass">>}
+        , {database, <<"mydb">>}
+        , {ping_with_auth, true}
+        , {v1_auth_transport, query_string}
+        , {version, v1}
+        ],
+    {ok, Client} = influxdb:start_client(Options),
+    try
+        ?assertEqual(true, influxdb:is_alive(Client))
+    after
+        ok = influxdb:stop_client(Client)
+    end.
+
 v2_is_alive_defaults_to_ping_without_auth_test() ->
     application:ensure_all_started(influxdb),
     ListenSocket = auth_header_ping_server_start(undefined),
@@ -598,6 +653,11 @@ auth_header_ping_server_start(ExpectedHeader) ->
     spawn_link(fun() -> auth_header_ping_server_serve(ListenSocket, ExpectedHeader) end),
     ListenSocket.
 
+ping_query_auth_server_start(ExpectedUser, ExpectedPassword) ->
+    {ok, ListenSocket} = gen_tcp:listen(0, [binary, {active, false}, {reuseaddr, true}]),
+    spawn_link(fun() -> ping_query_auth_server_serve(ListenSocket, ExpectedUser, ExpectedPassword) end),
+    ListenSocket.
+
 ping_auth_server_serve(ListenSocket, ExpectedAuthorization, SuccessStatusLine) ->
     {ok, Socket} = gen_tcp:accept(ListenSocket),
     {ok, Request} = gen_tcp:recv(Socket, 0, 5000),
@@ -622,6 +682,18 @@ auth_header_ping_server_serve(ListenSocket, ExpectedHeader) ->
     ok = gen_tcp:close(Socket),
     ok = gen_tcp:close(ListenSocket).
 
+ping_query_auth_server_serve(ListenSocket, ExpectedUser, ExpectedPassword) ->
+    {ok, Socket} = gen_tcp:accept(ListenSocket),
+    {ok, Request} = gen_tcp:recv(Socket, 0, 5000),
+    StatusLine =
+        case ping_query_auth_request_result(Request, ExpectedUser, ExpectedPassword) of
+            true -> <<"HTTP/1.1 204 No Content\r\n">>;
+            false -> <<"HTTP/1.1 401 Unauthorized\r\n">>
+        end,
+    _ = gen_tcp:send(Socket, [StatusLine, <<"Content-Length: 0\r\nConnection: close\r\n\r\n">>]),
+    ok = gen_tcp:close(Socket),
+    ok = gen_tcp:close(ListenSocket).
+
 auth_header_ping_request_result(Request, undefined) ->
     contains(Request, <<"GET /ping HTTP/">>) andalso
         not contains_ci(Request, <<"authorization: ">>);
@@ -636,6 +708,13 @@ ping_auth_request_result(Request, ExpectedAuthorization) ->
         not contains(Request, <<"GET /ping?">>) andalso
         not contains_ci(Request, <<"u=">>) andalso
         not contains_ci(Request, <<"p=">>).
+
+ping_query_auth_request_result(Request, ExpectedUser, ExpectedPassword) ->
+    contains(Request, <<"GET /ping?">>) andalso
+        contains(Request, <<"verbose=true">>) andalso
+        contains(Request, <<"u=", ExpectedUser/binary>>) andalso
+        contains(Request, <<"p=", ExpectedPassword/binary>>) andalso
+        not contains_ci(Request, <<"authorization: ">>).
 
 contains(Binary, Pattern) ->
     binary:match(Binary, Pattern) =/= nomatch.

--- a/src/influxdb.erl
+++ b/src/influxdb.erl
@@ -512,7 +512,7 @@ v1_is_alive_rejects_bad_ping_auth_when_enabled_test() ->
         ok = influxdb:stop_client(Client)
     end.
 
-v1_is_alive_with_ping_query_string_auth_enabled_test() ->
+v1_is_alive_with_ping_query_string_transport_enabled_test() ->
     application:ensure_all_started(influxdb),
     ListenSocket = ping_query_auth_server_start(<<"user">>, <<"pass">>),
     {ok, {_Addr, Port}} = inet:sockname(ListenSocket),
@@ -711,7 +711,6 @@ ping_auth_request_result(Request, ExpectedAuthorization) ->
 
 ping_query_auth_request_result(Request, ExpectedUser, ExpectedPassword) ->
     contains(Request, <<"GET /ping?">>) andalso
-        contains(Request, <<"verbose=true">>) andalso
         contains(Request, <<"u=", ExpectedUser/binary>>) andalso
         contains(Request, <<"p=", ExpectedPassword/binary>>) andalso
         not contains_ci(Request, <<"authorization: ">>).

--- a/src/influxdb_http.erl
+++ b/src/influxdb_http.erl
@@ -255,7 +255,7 @@ v1_ping_auth_query(Options) ->
     uri_string:compose_query(
         lists:reverse(
             add_query_param(password, "p",
-                add_query_param(username, "u", [{"verbose", "true"}], Options),
+                add_query_param(username, "u", [], Options),
             Options)
         )
     ).

--- a/src/influxdb_http.erl
+++ b/src/influxdb_http.erl
@@ -244,7 +244,13 @@ do_aysnc_write(Worker, Request, ReplayFunAndArgs) ->
 v1_ping_path(#{opts := Options}) ->
     case v1_query_string_ping_auth_enabled(Options) of
         true ->
-            "/ping?" ++ v1_ping_auth_query(Options);
+            Query = v1_ping_auth_query(Options),
+            case Query of
+                [] ->
+                    "/ping";
+                _ ->
+                    "/ping?" ++ Query
+            end;
         false ->
             "/ping"
     end;
@@ -300,6 +306,15 @@ ping_headers_removes_all_authorization_headers_when_auth_disabled_test() ->
         [{<<"Content-type">>, <<"text/plain; charset=utf-8">>}],
         ping_headers(Client)
     ).
+
+v1_ping_path_does_not_append_empty_query_string_test() ->
+    Client =
+        #{opts =>
+            [ {version, v1}
+            , {v1_auth_transport, query_string}
+            , {ping_with_auth, true}
+            ]},
+    ?assertEqual("/ping", v1_ping_path(Client)).
 -endif.
 
 pick_worker(#{pool := Pool, pool_type := hash}, Key) ->

--- a/src/influxdb_http.erl
+++ b/src/influxdb_http.erl
@@ -73,7 +73,7 @@ is_alive(v1, Client, ReturnReason) ->
 %% @doc Check authentication against the InfluxDB server.
 %% For v2, uses GET /api/v2/buckets with the Authorization header.
 %% For v3, uses POST /api/v3/query_sql with the Authorization header (empty body).
-%% For v1, uses GET /query (without "q" param) with Basic authentication header;
+%% For v1, uses GET /query (without "q" param) with configured credential transport;
 %%   returns ok on 200 or 400 (missing "q" means auth passed), error on 401.
 -spec check_auth(Client :: map()) -> ok | {error, not_authorized} | {error, term()}.
 check_auth(#{version := v2} = Client) ->
@@ -241,8 +241,29 @@ do_aysnc_write(Worker, Request, ReplayFunAndArgs) ->
     ok = ehttpc:request_async(Worker, post, Request, 5000, ReplayFunAndArgs),
     {ok, Worker}.
 
+v1_ping_path(#{opts := Options}) ->
+    case v1_query_string_ping_auth_enabled(Options) of
+        true ->
+            "/ping?" ++ v1_ping_auth_query(Options);
+        false ->
+            "/ping"
+    end;
 v1_ping_path(_Client) ->
     "/ping".
+
+v1_ping_auth_query(Options) ->
+    uri_string:compose_query(
+        lists:reverse(
+            add_query_param(password, "p",
+                add_query_param(username, "u", [{"verbose", "true"}], Options),
+            Options)
+        )
+    ).
+
+v1_query_string_ping_auth_enabled(Options) ->
+    proplists:get_value(version, Options, v1) =:= v1 andalso
+        proplists:get_value(v1_auth_transport, Options, header) =:= query_string andalso
+        ping_with_auth_enabled(Options).
 
 ping_with_auth_enabled(Options) ->
     proplists:get_value(ping_with_auth, Options, false) =:= true.
@@ -256,6 +277,14 @@ ping_headers(#{headers := Headers, opts := Options}) ->
     end;
 ping_headers(#{headers := Headers}) ->
     Headers.
+
+add_query_param(Key, Name, Acc, Options) ->
+    case proplists:get_value(Key, Options) of
+        undefined -> Acc;
+        Val when is_binary(Val) -> [{Name, binary_to_list(Val)} | Acc];
+        Val when is_list(Val) -> [{Name, Val} | Acc];
+        Val when is_atom(Val) -> [{Name, atom_to_list(Val)} | Acc]
+    end.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/test/influxdb_SUITE.erl
+++ b/test/influxdb_SUITE.erl
@@ -9,7 +9,7 @@
 all() -> [ t_encode_line
          , t_write
          , t_is_alive
-         , t_is_alive_v1_query_string_auth
+         , t_is_alive_v1_query_string_transport
          , t_check_auth
          , t_check_auth_v1_query_string_transport
          , t_check_auth_no_show_databases
@@ -99,7 +99,7 @@ t_is_alive(_) ->
     t_is_alive_(v2),
     t_is_alive_(v3).
 
-t_is_alive_v1_query_string_auth(_) ->
+t_is_alive_v1_query_string_transport(_) ->
     application:ensure_all_started(influxdb),
     Host = host(v1),
     Port = influxdb_port(v1),

--- a/test/influxdb_SUITE.erl
+++ b/test/influxdb_SUITE.erl
@@ -107,21 +107,16 @@ t_is_alive_v1_query_string_auth(_) ->
     Option0 = enable_ping_auth(options_with_v1_auth_transport(options(Host, Port, http, random, v1), query_string)),
     {ok, Client0} = influxdb:start_client(Option0),
     timer:sleep(500),
+    #{path := WritePath0, auth_path := AuthPath0, headers := Headers0} = Client0,
+    ?assertNotEqual(nomatch, string:find(WritePath0, "u=root")),
+    ?assertNotEqual(nomatch, string:find(WritePath0, "p=emqx%40123")),
+    ?assertNotEqual(nomatch, string:find(AuthPath0, "u=root")),
+    ?assertNotEqual(nomatch, string:find(AuthPath0, "p=emqx%40123")),
+    ?assertEqual(false, lists:keymember(<<"Authorization">>, 1, Headers0)),
     ?assertEqual(true, influxdb:is_alive(Client0, true), #{client => Client0}),
     ?assertEqual(true, influxdb:is_alive(Client0), #{client => Client0}),
     ok = influxdb:stop_client(Client0),
-
-    Option1 = enable_ping_auth(
-        options_with_v1_auth_transport(
-            options_wrong_credentials(Host, Port, http, random, v1),
-            query_string
-        )
-    ),
-    {ok, Client1} = influxdb:start_client(Option1),
-    timer:sleep(500),
-    ?assertMatch({false, _}, influxdb:is_alive(Client1, true), #{client => Client1}),
-    ?assertEqual(false, influxdb:is_alive(Client1), #{client => Client1}),
-    ok = influxdb:stop_client(Client1).
+    ok.
 
 t_is_alive_(Version) ->
     application:ensure_all_started(influxdb),
@@ -210,7 +205,7 @@ options(Host, Port, WriteProtocol, PoolType, Version) when Version =:= v1 ->
     PassWord = <<"emqx@123">>,
     DataBase = <<"mqtt">>,
     Precision = <<"ns">>,
-    Pool = <<"influxdb_test">>,
+    Pool = pool_name("influxdb_test"),
     PoolSize = 16,
     [ {host, Host}
     , {port, Port}
@@ -229,7 +224,7 @@ options(Host, Port, WriteProtocol, PoolType, Version) when Version =:= v2 ->
     HttpsEnabled = false,
     Token = <<"abcdefg">>,
     Precision = <<"ns">>,
-    Pool = <<"influxdb_test">>,
+    Pool = pool_name("influxdb_test"),
     PoolSize = 16,
     [ {host, Host}
     , {port, Port}
@@ -246,7 +241,7 @@ options(Host, Port, WriteProtocol, PoolType, Version) when Version =:= v3 ->
     HttpsEnabled = false,
     Token = v3_token(HttpsEnabled),
     Precision = <<"ns">>,
-    Pool = <<"influxdb_test">>,
+    Pool = pool_name("influxdb_test"),
     PoolSize = 16,
     Database = <<"mqtt">>,
     [ {host, Host}
@@ -275,6 +270,9 @@ options_with_v1_auth_transport(Options, Transport) ->
 
 enable_ping_auth(Options) ->
     [{ping_with_auth, true} | proplists:delete(ping_with_auth, Options)].
+
+pool_name(Prefix) ->
+    list_to_binary(Prefix ++ "_" ++ integer_to_list(erlang:unique_integer([positive]))).
 
 shared_secret_path() ->
     os:getenv("CI_SHARED_SECRET_PATH", "/var/lib/secret").

--- a/test/influxdb_SUITE.erl
+++ b/test/influxdb_SUITE.erl
@@ -9,7 +9,9 @@
 all() -> [ t_encode_line
          , t_write
          , t_is_alive
+         , t_is_alive_v1_query_string_auth
          , t_check_auth
+         , t_check_auth_v1_query_string_transport
          , t_check_auth_no_show_databases
          ].
 
@@ -97,6 +99,30 @@ t_is_alive(_) ->
     t_is_alive_(v2),
     t_is_alive_(v3).
 
+t_is_alive_v1_query_string_auth(_) ->
+    application:ensure_all_started(influxdb),
+    Host = host(v1),
+    Port = influxdb_port(v1),
+
+    Option0 = enable_ping_auth(options_with_v1_auth_transport(options(Host, Port, http, random, v1), query_string)),
+    {ok, Client0} = influxdb:start_client(Option0),
+    timer:sleep(500),
+    ?assertEqual(true, influxdb:is_alive(Client0, true), #{client => Client0}),
+    ?assertEqual(true, influxdb:is_alive(Client0), #{client => Client0}),
+    ok = influxdb:stop_client(Client0),
+
+    Option1 = enable_ping_auth(
+        options_with_v1_auth_transport(
+            options_wrong_credentials(Host, Port, http, random, v1),
+            query_string
+        )
+    ),
+    {ok, Client1} = influxdb:start_client(Option1),
+    timer:sleep(500),
+    ?assertMatch({false, _}, influxdb:is_alive(Client1, true), #{client => Client1}),
+    ?assertEqual(false, influxdb:is_alive(Client1), #{client => Client1}),
+    ok = influxdb:stop_client(Client1).
+
 t_is_alive_(Version) ->
     application:ensure_all_started(influxdb),
     Host = host(Version),
@@ -129,6 +155,29 @@ t_check_auth(_) ->
     t_check_auth_(v1),
     t_check_auth_(v2),
     t_check_auth_(v3).
+
+t_check_auth_v1_query_string_transport(_) ->
+    application:ensure_all_started(influxdb),
+    Host = host(v1),
+    Port = influxdb_port(v1),
+    Option0 = options_with_v1_auth_transport(options(Host, Port, http, random, v1), query_string),
+    {ok, Client0} = influxdb:start_client(Option0),
+    timer:sleep(500),
+    #{auth_path := AuthPath0, headers := Headers0} = Client0,
+    ?assertNotEqual(nomatch, string:find(AuthPath0, "u=root")),
+    ?assertNotEqual(nomatch, string:find(AuthPath0, "p=emqx%40123")),
+    ?assertEqual(false, lists:keymember(<<"Authorization">>, 1, Headers0)),
+    ?assertEqual(ok, influxdb:check_auth(Client0)),
+    ok = influxdb:stop_client(Client0),
+
+    Option1 = options_with_v1_auth_transport(
+        options_wrong_credentials(Host, Port, http, random, v1),
+        query_string
+    ),
+    {ok, Client1} = influxdb:start_client(Option1),
+    timer:sleep(500),
+    ?assertEqual({error, not_authorized}, influxdb:check_auth(Client1)),
+    ok = influxdb:stop_client(Client1).
 
 t_check_auth_(Version) ->
     application:ensure_all_started(influxdb),
@@ -220,6 +269,12 @@ options_wrong_credentials(Host, Port, WriteProtocol, PoolType, Version) when Ver
 options_wrong_credentials(Host, Port, WriteProtocol, PoolType, Version) when Version =:= v2; Version =:= v3 ->
     Options = options(Host, Port, WriteProtocol, PoolType, Version),
     lists:keyreplace(token, 1, Options, {token, <<"wrong_token">>}).
+
+options_with_v1_auth_transport(Options, Transport) ->
+    [{v1_auth_transport, Transport} | proplists:delete(v1_auth_transport, Options)].
+
+enable_ping_auth(Options) ->
+    [{ping_with_auth, true} | proplists:delete(ping_with_auth, Options)].
 
 shared_secret_path() ->
     os:getenv("CI_SHARED_SECRET_PATH", "/var/lib/secret").


### PR DESCRIPTION
## Summary

Adds a v1-only auth transport option so callers can choose how `username` / `password` credentials are sent.

## Changes

- add `{v1_auth_transport, header | query_string}` for InfluxDB v1
- keep the default as `header`, preserving the current Basic Auth behavior
- support `{v1_auth_transport, query_string}` for databases that require `u` / `p` URL query parameters
- apply the same transport choice to v1 write paths, `check_auth`, and `ping_with_auth`
- document the option and update option types
- add EUnit coverage for both header and query-string transports

## Impact

- existing v1 clients keep using `Authorization: Basic ...` by default
- clients that need legacy-compatible URL credentials can opt in with `{v1_auth_transport, query_string}`
- v2/v3 behavior is unchanged

## Validation

- `rebar3 eunit --module=influxdb --module=influxdb_http`
- `rebar3 xref`
- `rebar3 dialyzer`
